### PR TITLE
Fixed submodules not being found and extra install

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ pip install 'git+git://github.com/virelay/corelay'
 
 To install optional HDBSCAN and UMAP support, use
 ```shell
-$ pip install 'git+git://github.com/virelay/corelay[umap,hdbscan]'
+$ pip install 'git+git://github.com/virelay/corelay#egg=corelay[umap,hdbscan]'
 ```
 
 ## Usage

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
     name='corelay',
     use_scm_version=True,
-    packages=['corelay'],
+    packages=find_packages(include=['corelay*']),
     install_requires=[
         'h5py>=2.9.0',
         'matplotlib>=3.0.3',


### PR DESCRIPTION
Installing extra_require packages must be installed somewhat differently
than was shown in the README, this was updated. Submodules of corelay
were also not found when directly installing from an URL, using
setuptools find_packages with a specified include fixed this.