### PR TITLE
adding perplexity parameter to TSNE

### DIFF
--- a/corelay/processor/embedding.py
+++ b/corelay/processor/embedding.py
@@ -66,10 +66,14 @@ class TSNEEmbedding(Embedding):
     """
     n_components = Param(int, default=2, identifier=True)
     metric = Param(str, default='euclidean', identifier=True)
+    perplexity = Param(float, default=30., identifier=True)
 
     def function(self, data):
         # pylint: disable=not-a-mapping
-        tsne = TSNE(n_components=self.n_components, metric=self.metric, **self.kwargs)
+        tsne = TSNE(n_components=self.n_components,
+                    metric=self.metric,
+                    perplexity=self.perplexity,
+                    **self.kwargs)
         emb = tsne.fit_transform(data)
         return emb
 

--- a/corelay/processor/embedding.py
+++ b/corelay/processor/embedding.py
@@ -67,12 +67,14 @@ class TSNEEmbedding(Embedding):
     n_components = Param(int, default=2, identifier=True)
     metric = Param(str, default='euclidean', identifier=True)
     perplexity = Param(float, default=30., identifier=True)
+    early_exaggeration = Param(float, default=12., identifier=True)
 
     def function(self, data):
         # pylint: disable=not-a-mapping
         tsne = TSNE(n_components=self.n_components,
                     metric=self.metric,
                     perplexity=self.perplexity,
+                    early_exaggeration=self.early_exaggeration,
                     **self.kwargs)
         emb = tsne.fit_transform(data)
         return emb


### PR DESCRIPTION
TSNE should have an optional perplexity parameter.
The default value of 30 is set to the default of sklearn.manifold.TSNE

lower perplexity means more focus on local structures. higher perplexity means higher consideration of global structures