### PR TITLE
Docs: Add Sphinx Documentation

### DIFF
--- a/corelay/pipeline/__init__.py
+++ b/corelay/pipeline/__init__.py
@@ -1,0 +1,1 @@
+'''Base and built-in Pipelines.'''

--- a/corelay/pipeline/base.py
+++ b/corelay/pipeline/base.py
@@ -40,10 +40,10 @@ class Task(Slot):
     Attributes
     ----------
     proc_type : type
-        Class of the :obj:`Processor`s allowed for this :obj:`Task`.
-    default : :obj:`Processor` or :obj:`types.FunctionType` or :obj:`types.MethodType` Default :obj:`Processor` to use
-        if no Processor is assigned. If a :obj:`types.FunctionType` or :obj:`types.MethodType`, an appropriate
-        :obj:`FunctionProcessor` will be created.
+        Class of the :obj:`Processor` allowed for this :obj:`Task`.
+    default : :obj:`Processor` or :obj:`types.FunctionType` or :obj:`types.MethodType`
+        Default :obj:`Processor` to use if no Processor is assigned. If a :obj:`types.FunctionType` or
+        :obj:`types.MethodType`, an appropriate :obj:`FunctionProcessor` will be created.
     proc_kwargs : dict
         Keyword arguments to overwrite on the supplied Processor.
 
@@ -54,7 +54,7 @@ class Task(Slot):
         Parameters
         ----------
         proc_type : type
-            Class of the :obj:`Processor`s allowed for this :obj:`Task`.
+            Class of the :obj:`Processor` allowed for this :obj:`Task`.
         default : :obj:`Processor` or :obj:`types.FunctionType` or :obj:`types.MethodType` Default :obj:`Processor` to
             use if no Processor is assigned. If a :obj:`types.FunctionType` or :obj:`types.MethodType`, an appropriate
             :obj:`FunctionProcessor` will be created.
@@ -91,21 +91,21 @@ class Pipeline(Processor):
     Attributes
     ----------
     task_scheme : :obj:`collections.OrderedDict`
-        OrderedDict of Tasks which can be filled with :obj:`Processor`s.
+        OrderedDict of Tasks which can be filled with :obj:`Processor`.
     processes : :obj:`collections.OrderedDict`
-        OrderedDict of the :obj:`Processor`s that filled the `task_scheme`.
+        OrderedDict of the :obj:`Processor` that filled the `task_scheme`.
 
     """
 
     def checkpoint_processes(self):
         """Find the checkpoint :obj:`Processor` closest to output and return an
-        :obj:`collections.OrderedDict` of that and all following :obj:`Processor`s.
+        :obj:`collections.OrderedDict` of that and all following :obj:`Processor`.
 
         Returns
         -------
         :obj:`collections.OrderedDict`
             The :obj:`Processor` that is the checkpoint closest to output and all its following
-            :obj:`Processor`s in an :obj:`OrderedDict`.
+            :obj:`Processor` in an :obj:`OrderedDict`.
 
         Raises
         ------
@@ -159,7 +159,7 @@ class Pipeline(Processor):
         Returns
         -------
         object
-            Output of all :obj:`Processor`s that are flagged as pipeline outputs. If no processors
+            Output of all :obj:`Processor` that are flagged as pipeline outputs. If no processors
             are flagged as outputs, return the output of the last processor.
 
         """
@@ -175,7 +175,11 @@ class Pipeline(Processor):
         return tuple(outputs)
 
     def __repr__(self):
-        """Example of the pipeline representation:
+        """Represent a Pipeline as str.
+
+        Example
+        -------
+        >>> MyPipeline()
         MyPipeline(
             FunctionProcessor(function=(lambda x: x.mean(1)),) -> output:np.ndarray
             SciPyPDist(metric=sqeuclidean) -> output:np.ndarray

--- a/corelay/pipeline/spectral.py
+++ b/corelay/pipeline/spectral.py
@@ -27,11 +27,11 @@ class SpectralEmbedding(Pipeline):
     laplacian : callable, optional
         laplacian function of signature: (distance : :obj:`numpy.ndarray`,) -> :obj:`numpy.ndarray`
 
-    Note
-    ----
-    Pre-computed distance matrices can be supplied by passing `pairwise_distance`=(lambda x: x).
-    Pre-computed affinity matrices can be supplied by additionally passing `affinity`=(lambda x: x).
-    Pre-computed graph laplacian matrices can be supplied by further passing `laplacian`=(lambda x: x).
+    Notes
+    -----
+    Pre-computed distance matrices can be supplied by passing ``pairwise_distance=(lambda x: x)``.
+    Pre-computed affinity matrices can be supplied by additionally passing ``affinity=(lambda x: x)``.
+    Pre-computed graph laplacian matrices can be supplied by further passing ``laplacian=(lambda x: x)``.
 
     """
     preprocessing = Task(default=(lambda x: x))

--- a/corelay/processor/__init__.py
+++ b/corelay/processor/__init__.py
@@ -1,0 +1,1 @@
+'''Base and built-in Processors.'''

--- a/corelay/processor/clustering.py
+++ b/corelay/processor/clustering.py
@@ -139,7 +139,7 @@ class AgglomerativeClustering(Clustering):
 
 
 class Dendrogram(Clustering):
-    """Dendrogram
+    """Dendrogram.
 
     Parameters
     ----------

--- a/corelay/processor/preprocessing.py
+++ b/corelay/processor/preprocessing.py
@@ -52,7 +52,8 @@ class Histogram(PreProcessor):
 
 
 class ImagePreProcessor(PreProcessor):
-    """
+    """Abstract PreProcessor for Images.
+
     Parameters
     ----------
     filter : int

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx-copybutton>=0.4.0
+sphinx-rtd-theme>=1.0.0
+sphinxcontrib.datatemplates>=0.9.0
+sphinxcontrib.bibtex>=2.4.1

--- a/docs/source/_static/favicon.svg
+++ b/docs/source/_static/favicon.svg
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="76.210648mm"
+   height="135.3506mm"
+   viewBox="0 0 76.210645 135.3506"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04, custom)"
+   sodipodi:docname="favicon.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient4814"
+       inkscape:collect="always">
+      <stop
+         id="stop4810"
+         offset="0"
+         style="stop-color:#e23bfc;stop-opacity:1" />
+      <stop
+         id="stop4812"
+         offset="1"
+         style="stop-color:#6cbbfc;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4621">
+      <stop
+         style="stop-color:#f7f779;stop-opacity:1"
+         offset="0"
+         id="stop4617" />
+      <stop
+         style="stop-color:#abe17f;stop-opacity:1"
+         offset="1"
+         id="stop4619" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4613">
+      <stop
+         style="stop-color:#abe17f;stop-opacity:1"
+         offset="0"
+         id="stop4609" />
+      <stop
+         style="stop-color:#f7f679;stop-opacity:1"
+         offset="1"
+         id="stop4611" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4601">
+      <stop
+         style="stop-color:#f7f679;stop-opacity:1"
+         offset="0"
+         id="stop4597" />
+      <stop
+         style="stop-color:#abe17f;stop-opacity:1"
+         offset="1"
+         id="stop4599" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4601"
+       id="linearGradient4603"
+       x1="65.956841"
+       y1="125.62284"
+       x2="141.2686"
+       y2="67.662949"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(89.642798,33.441424)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4613"
+       id="linearGradient4615"
+       x1="66.687721"
+       y1="108.36105"
+       x2="139.11861"
+       y2="152.2063"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(89.642798,33.441424)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4621"
+       id="linearGradient4623"
+       x1="65.626114"
+       y1="203.01355"
+       x2="136.21317"
+       y2="142.21883"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(89.642798,33.441424)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4814"
+       id="linearGradient4762"
+       gradientUnits="userSpaceOnUse"
+       x1="42.309093"
+       y1="203.36531"
+       x2="138.71141"
+       y2="152.41968"
+       gradientTransform="matrix(0,1.3616662,1.0745492,0,-95.002217,40.299544)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.9899495"
+     inkscape:cx="38.890873"
+     inkscape:cy="296.47977"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer2"
+     showgrid="true"
+     showguides="true"
+     inkscape:window-width="1916"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="SPRINCL Logo"
+     transform="translate(-59.32511,-23.195302)">
+    <g
+       id="g4828"
+       transform="translate(-95.682493,-77.909068)">
+      <path
+         sodipodi:nodetypes="ccscsc"
+         style="fill:url(#linearGradient4623);fill-opacity:1"
+         d="m 155.26891,236.45497 c 0.75595,0 55.5625,-24.09599 55.5625,-24.09599 0,0 20.31622,-8.12648 20.31622,-28.25372 0,-20.12723 -63.21652,12.94569 -63.21652,12.94569 0,0 -12.6622,6.42559 -12.6622,18.52083 z"
+         id="path3736-3"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccscsc"
+         style="fill:url(#linearGradient4603);fill-opacity:1"
+         d="m 230.9114,101.10437 c -0.75595,0 -55.5625,24.09598 -55.5625,24.09598 0,0 -20.31622,8.15011 -20.31622,28.25372 0,20.12723 63.21652,-12.94569 63.21652,-12.94569 0,0 12.6622,-5.82319 12.6622,-18.52083 z"
+         id="path3736"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="cscccsscc"
+         inkscape:connector-curvature="0"
+         id="path3734"
+         d="m 224.00152,202.79177 c 0,0 7.46112,-6.98357 7.21056,-20.895 -0.32332,-17.95095 -13.90782,-21.92261 -13.90782,-21.92261 L 175.3489,147.02847 c 0,0 -19.56183,-6.96127 -11.03493,-14.43253 0,0 -9.50369,7.91867 -9.30324,21.39185 0.15744,10.58216 2.28981,19.21553 13.15662,22.99529 10.86681,3.77977 47.625,15.59152 47.625,15.59152 0,0 8.20917,2.28262 8.20917,10.21717 z"
+         style="fill:url(#linearGradient4615);fill-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -1,0 +1,70 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+   :members:
+   :show-inheritance:
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+      :nosignatures:
+
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :nosignatures:
+
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :nosignatures:
+
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :nosignatures:
+
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/source/bibliography.bib
+++ b/docs/source/bibliography.bib
@@ -1,0 +1,14 @@
+
+@article{anders2021software,
+  author    = {Christopher J. Anders and
+               David Neumann and
+               Wojciech Samek and
+               Klaus{-}Robert M{\"{u}}ller and
+               Sebastian Lapuschkin},
+  title     = {Software for Dataset-wide {XAI:} From Local Explanations to Global
+               Insights with Zennit, CoRelAy, and ViRelAy},
+  journal   = {CoRR},
+  volume    = {abs/2106.13200},
+  year      = {2021},
+  url       = {https://arxiv.org/abs/2106.13200},
+}

--- a/docs/source/bibliography.rst
+++ b/docs/source/bibliography.rst
@@ -1,0 +1,5 @@
+============
+Bibliography
+============
+
+.. bibliography::

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,143 @@
+import sys
+import os
+from subprocess import run, CalledProcessError
+import inspect
+import pkg_resources
+
+from pybtex.style.formatting.plain import Style as PlainStyle
+from pybtex.style.labels import BaseLabelStyle
+from pybtex.plugin import register_plugin
+
+
+# -- Project information -----------------------------------------------------
+project = 'corelay'
+copyright = '2021, corelay'
+author = 'corelay'
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.linkcode',
+    'sphinx.ext.imgmath',
+    'sphinx.ext.extlinks',
+    'sphinx_rtd_theme',
+    'sphinx_copybutton',
+    'sphinxcontrib.datatemplates',
+    'sphinxcontrib.bibtex',
+]
+
+
+def config_inited_handler(app, config):
+    os.makedirs(os.path.join(app.srcdir, app.config.generated_path), exist_ok=True)
+
+
+def autodoc_skip_member_handler(app, what, name, obj, skip, options):
+    if isinstance(obj, property):
+        return True
+    return None
+
+
+def setup(app):
+    app.add_config_value('generated_path', '_generated', 'env')
+    app.connect('config-inited', config_inited_handler)
+    app.connect('autodoc-skip-member', autodoc_skip_member_handler)
+
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+copybutton_line_continuation_character = "\\"
+copybutton_here_doc_delimiter = "EOT"
+
+html_theme = 'sphinx_rtd_theme'
+html_favicon = '_static/favicon.svg'
+html_static_path = ['_static']
+
+bibtex_bibfiles = ['bibliography.bib']
+bibtex_default_style = 'author_year_style'
+bibtex_reference_style = 'author_year'
+
+
+class AuthorYearLabelStyle(BaseLabelStyle):
+    def format_labels(self, sorted_entries):
+        for entry in sorted_entries:
+            yield f'[{entry.persons["author"][0].last_names[0]} et al., {entry.fields["year"]}]'
+
+
+class AuthorYearStyle(PlainStyle):
+    default_label_style = AuthorYearLabelStyle
+
+
+register_plugin('pybtex.style.formatting', 'author_year_style', AuthorYearStyle)
+
+
+def getrev():
+    try:
+        revision = run(
+            ['git', 'describe', '--tags', 'HEAD'],
+            capture_output=True,
+            check=True,
+            text=True
+        ).stdout[:-1]
+    except CalledProcessError:
+        revision = 'master'
+
+    return revision
+
+
+REVISION = getrev()
+
+extlinks = {
+    'repo': (
+        f'https://github.com/virelay/corelay/blob/{REVISION}/%s',
+        '%s'
+    )
+}
+
+LINKCODE_URL = (
+    f'https://github.com/virelay/corelay/blob/{REVISION}'
+    '/{filepath}#L{linestart}-L{linestop}'
+)
+
+
+# revised from https://gist.github.com/nlgranger/55ff2e7ff10c280731348a16d569cb73
+def linkcode_resolve(domain, info):
+    if domain != 'py' or not info['module']:
+        return None
+
+    modname = info['module']
+    topmodulename = modname.split('.')[0]
+    fullname = info['fullname']
+
+    submod = sys.modules.get(modname)
+    if submod is None:
+        return None
+
+    obj = submod
+    for part in fullname.split('.'):
+        try:
+            obj = getattr(obj, part)
+        except Exception:
+            return None
+
+    try:
+        modpath = pkg_resources.require(topmodulename)[0].location
+        filepath = os.path.relpath(inspect.getsourcefile(obj), modpath)
+        if filepath is None:
+            return
+    except Exception:
+        return None
+
+    try:
+        source, lineno = inspect.getsourcelines(obj)
+    except OSError:
+        return None
+    else:
+        linestart, linestop = lineno, lineno + len(source) - 1
+
+    return LINKCODE_URL.format(filepath=filepath, linestart=linestart, linestop=linestop)

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -1,0 +1,268 @@
+================
+ Getting started
+================
+
+CoRelAy is a tool to compose small-scale (single-machine) analysis pipelines. It
+was created to swiftly implement pipelines to generate analysis data which can
+then be visualized using ViRelAy.
+
+Install
+-------
+
+CoRelAy can be installed directly from PyPI:
+
+.. code-block:: console
+
+   $ pip install virelay
+
+To install optional HDBSCAN and UMAP support, use
+
+.. code-block:: console
+
+    $ pip install corelay[umap,hdbscan]
+
+For the current development version, or to try out examples, clone and install
+with:
+
+.. code-block:: console
+
+   $ git clone https://github.com/virelay/virelay.git
+   $ pip install ./virelay
+
+Basic Usage
+-----------
+
+The main objective of ViRelAy is the quick and hassle-free composition of
+analysis **Pipelines**. **Pipelines** are designed with a number of steps,
+called **Task**, which each have their own default function, defined using a
+**Processor**. Any step of the pipeline may be individually changed by assigning
+a new **Processor**. **Processors** have **Params** which configure their
+functional hyperparameters.
+
+
+Processor and Param
+^^^^^^^^^^^^^^^^^^^
+
+A **Processor** can be defined in the following way:
+
+.. code-block:: python
+
+    import numpy as np
+
+    from corelay.processor.base import Processor, Param
+    from types import FunctionType
+
+
+    class MyProcess(Processor):
+        # Parameters are registered by defining a class attribute of type Param,
+        # and will be set in __init__ automatically, which expects keyword
+        # arguments with the same name the first value is a type specification,
+        # the second a default value
+        stuff = Param(dtype=int, default=2)
+        # as class methods have to be bound explicitly, func here acts like a
+        # static function of MyProcess. For more information see
+        # corelay.processor.base.FunctionProcessor
+        func = Param(FunctionType, lambda x: x**2)
+
+        # Parameters can be accessed as self.<parameter-name>
+        def function(self, data):
+            return self.stuff * self.func(data) + 3
+
+Every **Processor** is a subclass of
+:py:class:`~corelay.processor.base.Processor`, and must implement
+:py:meth:`~corelay.processor.base.Processor.function`, which typically only uses
+a single positional argument.
+Parameters for the Processor can be specified by assigning an instance of
+:py:class:`~corelay.processor.base.Param` as a class attribute.
+The name of the attribute can be used as a keyword argument to specify the value
+when creating an instance of the **Processor**, and accessed under the same name.
+Each **Param** has a datatype ``dtype`` and a default value ``default``.
+**Processor** instances can be used like functions, or assigned to a **Task** of
+a **Pipeline**.
+
+Pipeline and Task
+^^^^^^^^^^^^^^^^^
+
+**Pipelines** consist of multiple, sequential, pre-determined steps, called
+**Tasks**, and can be defined in the following way:
+
+.. code-block:: python
+
+    from corelay.pipeline.base import Pipeline, Task
+    from corelay.processor.base import FunctionProcessor
+    from corelay.processor.affinity import Affinity, RadialBasisFunction
+    from corelay.processor.distance import Distance, SciPyPDist
+
+
+    class MyPipeline(Pipeline):
+        # Task are registered in order by creating a class attribute of type
+        # Task() and, like params, are expected to be supplied with the same name
+        # in __init__ as a keyword argument. The first value is an optional
+        # expected Process type, second is a default value, which has to be an
+        # instance of that type. If the default argument is not a Process, it will
+        # be converted to a FunctionProcessor by default, functions fed to
+        # FunctionProcessors are by default not bound to the class. To bind them,
+        # we can supply `bind_method=True` to the FunctionProcessor. Supplying it
+        # to the task changes the default value of the Processor before creation:
+        prepreprocess = Task(
+            proc_type=FunctionProcessor,
+            default=(lambda self, x: x * 2),
+            bind_method=True
+        )
+        # Otherwise, we do not need to supply `self` for the default function:
+        preprocess = Task(proc_type=FunctionProcessor, default=(lambda x: x**2))
+        pdistance = Task(Distance, SciPyPDist(metric='sqeuclidean'))
+        affinity = Task(Affinity, RadialBasisFunction(sigma=1.0))
+        # empty task, does nothing (except return input) by default
+        postprocess = Task()
+
+Every **Pipeline** is a subclass of :py:class:`~corelay.pipeline.base.Pipeline`.
+**Tasks** of a pipeline are created by assigning an instance of
+:py:class:`~corelay.pipeline.base.Task` as a class attribute, similar to
+**Params** in **Processors**.
+Each **Task** has, each optional, a **Processor**-type ``proc_type``, a default
+**Processor** for the Task ``default``. Additional keyword arguments can be
+specified as default parameter values that should be assigned to any
+**Processor** that is used for the **Task**. The keyword argument
+``bind_method`` is specific to :py:class:`~corelay.processor.base.FunctionProcessor`,
+and describes, whether the function is static (default, ``bind_method=False``),
+or whether it should have access to the **Processor** instance.
+Functions can be passed instead of **Processors**, which will be implicitly
+converted to a :py:class:`~corelay.processor.base.FunctionProcessor`.
+**Tasks** can be assigned by passing **Processors** with their respective
+keyword argument during instantiation of the **Pipeline**, or by directly
+assigning them to the respective attribute.
+
+**Pipelines** and **Processors** can be instantiated and used in the following
+way:
+
+.. code-block:: python
+
+    import numpy as np
+
+    from corelay.processor.base import FunctionProcessor
+    from corelay.processor.affinity import RadialBasisFunction
+    from types import FunctionType
+
+    # Use Pipeline 'as is'
+    pipeline = MyPipeline()
+    output1 = pipeline(np.random.rand(5, 3))
+    print('Pipeline output:', output1)
+
+    # Tasks are filled with Processes during initialization of the Pipeline
+    # class keyword arguments do not have to be in order, and if not supplied,
+    # the default value will be used
+    custom_pipeline = MyPipeline(
+        # The pipeline's Task sets the `bind_method` Parameter's default to
+        # True. Supplying a value here avoids falling back to the default
+        # value, and thus we do not need a `self` argument for our function:
+        prepreprocess=FunctionProcessor(
+            function=(lambda x: x + 1), bind_method=False
+        ),
+        preprocess=(lambda x: x.mean(1)),
+        postprocess = MyProcess(stuff=3)
+    )
+    custom_pipeline.affinity = RadialBasisFunction(sigma=.1),
+    output2 = custom_pipeline(np.ones((5, 3, 5)))
+    print('Custom pipeline output:', output2)
+
+Like **Processors**, executing a **Pipeline** can be done by simply calling it
+like a function.
+
+Examples
+--------
+
+More examples to highlight some features of **CoRelAy** can be found in
+:repo:`example/`. The following demonstrates, how to create a functional
+pipeline based on :py:class:`corelay.pipeline.spectral.SpectralClustering`. A
+similar version of the following code may be found in
+:repo:`example/memoize_spectral_pipeline.py`.
+
+.. code-block:: python
+
+    import time
+
+    import h5py
+    import numpy as np
+
+    from corelay.base import Param
+    from corelay.processor.base import Processor
+    from corelay.processor.flow import Sequential, Parallel
+    from corelay.pipeline.spectral import SpectralClustering
+    from corelay.processor.clustering import KMeans
+    from corelay.processor.embedding import TSNEEmbedding, EigenDecomposition
+    from corelay.io.storage import HashedHDF5
+
+
+    # custom processors can be implemented by defining a function attribute
+    class Flatten(Processor):
+        def function(self, data):
+            return data.reshape(data.shape[0], np.prod(data.shape[1:]))
+
+
+    class SumChannel(Processor):
+        # parameters can be assigned by defining a class-owned Param instance
+        axis = Param(int, 1)
+        def function(self, data):
+            return data.sum(1)
+
+
+    class Normalize(Processor):
+        def function(self, data):
+            data = data / data.sum((1, 2), keepdims=True)
+            return data
+
+
+    np.random.seed(0xDEADBEEF)
+    fpath = 'test.analysis.h5'
+    with h5py.File(fpath, 'a') as fd:
+        # HashedHDF5 is an io-object that stores outputs of Processors based on
+        # hashes in hdf5
+        iobj = HashedHDF5(fd.require_group('proc_data'))
+
+        # generate some exemplary data
+        data = np.random.normal(size=(64, 3, 32, 32))
+        n_clusters = range(2, 20)
+
+        # SpectralClustering is an Example for a pre-defined Pipeline
+        pipeline = SpectralClustering(
+            # processors, such as EigenDecomposition, can be assigned to
+            # pre-defined tasks
+            embedding=EigenDecomposition(n_eigval=8, io=iobj),
+            # flow-based Processors, such as Parallel, can combine multiple
+            # Processors broadcast=True copies the input as many times as there
+            # are Processors broadcast=False instead attempts to match each
+            # input to a Processor
+            clustering=Parallel([
+                Parallel([
+                    KMeans(n_clusters=k, io=iobj) for k in n_clusters
+                ], broadcast=True),
+                # io-objects will be used during computation when supplied to
+                # Processors if a corresponding output value (here identified by
+                # hashes) already exists, the value is not computed again but
+                # instead loaded from the io object
+                TSNEEmbedding(io=iobj)
+            ], broadcast=True, is_output=True)
+        )
+        # Processors (and Params) can be updated by simply assigning
+        # corresponding attributes
+        pipeline.preprocessing = Sequential([
+            SumChannel(),
+            Normalize(),
+            Flatten()
+        ])
+
+        start_time = time.perf_counter()
+
+        # Processors flagged with "is_output=True" will be accumulated in the
+        # output the output will be a tree of tuples, with the same hierarchy as
+        # the pipeline (i.e. clusterings here contains a tuple of the k-means
+        # outputs)
+        clusterings, tsne = pipeline(data)
+
+        # since we store our results in a hdf5 file, subsequent calls will not
+        # compute the values (for the same inputs), but rather load them from the
+        # hdf5 file try running the script multiple times
+        duration = time.perf_counter() - start_time
+        print(f'Pipeline execution time: {duration:.4f} seconds')
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,51 @@
+=====================
+CoRelAy Documentation
+=====================
+
+CoRelAy is a tool to compose small-scale (single-machine) analysis pipelines. It
+was created to swiftly implement pipelines to generate analysis data which can
+then be visualized using ViRelAy.
+
+CoRelAy is available on PyPI and can be installed with:
+
+.. code-block:: console
+
+   $ pip install corelay
+
+Contents
+--------
+
+.. toctree::
+    :maxdepth: 2
+
+    getting-started
+    reference/index
+    bibliography
+
+Indices and tables
+------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+
+Citing
+------
+
+If you find CoRelAy useful, why not cite our paper :cite:p:`anders2021software`:
+
+.. code-block:: bibtex
+
+    @article{anders2021software,
+          author  = {Anders, Christopher J. and
+                     Neumann, David and
+                     Samek, Wojciech and
+                     Müller, Klaus-Robert and
+                     Lapuschkin, Sebastian},
+          title   = {Software for Dataset-wide XAI: From Local Explanations to Global Insights with {Zennit}, {CoRelAy}, and {ViRelAy}},
+          journal = {CoRR},
+          volume  = {abs/2106.13200},
+          year    = {2021},
+    }
+

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -1,0 +1,17 @@
+================
+ API Reference
+================
+
+.. autosummary::
+    :toctree:
+    :nosignatures:
+    :recursive:
+
+    corelay.base
+    corelay.io
+    corelay.pipeline
+    corelay.plugboard
+    corelay.processor
+    corelay.tracker
+    corelay.utils
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,62 @@
 [tox]
-skip_missing_interpreters = True
-envlist = py38,pylint,flake8
+skip_missing_interpreters = true
+envlist = py37,py38,py39,pylint,flake8,docs
+
+[testenv]
+deps =
+   pytest
+   pytest-cov
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage.{envname}
+commands =
+    pytest \
+        --cov "{envsitepackagesdir}/corelay" \
+        --cov-config "{toxinidir}/tox.ini" \
+        {posargs:.}
+
+[testenv:coverage]
+deps =
+   coverage
+setenv =
+    COVERAGE_FILE = {toxworkdir}/.coverage
+skip_install = true
+commands =
+    coverage combine
+    coverage report -m
+depends = py37,py38,py39
+
+[testenv:docs]
+basepython = python3.9
+deps =
+    -r {toxinidir}/docs/requirements.txt
+commands =
+    sphinx-build \
+        --color \
+        -W \
+        --keep-going \
+        -d "{toxinidir}/docs/doctree" \
+        -b html \
+        "{toxinidir}/docs/source" \
+        "{toxinidir}/docs/build" \
+        {posargs}
+
+[testenv:flake8]
+basepython = python3.9
+changedir = {toxinidir}
+deps =
+    flake8
+commands =
+    flake8 "{toxinidir}/corelay" "{toxinidir}/tests" {posargs}
+
+
+[testenv:pylint]
+basepython = python3.9
+deps =
+    pylint
+    pytest
+changedir = {toxinidir}
+commands =
+    pylint --rcfile=pylintrc --output-format=parseable {toxinidir}/corelay {toxinidir}/tests
 
 [flake8]
 # R0902 Too many instance attributes
@@ -13,27 +69,19 @@ exclude=.venv,.git,.tox,build,dist,docs,*egg,*.ini
 
 max-line-length = 120
 
-[testenv]
-deps =
-   pytest
-   pytest-cov
-setenv =
-    COVERAGE_FILE = {toxinidir}/.coverage.{envname}
-commands =
-    python -m pytest --cov=corelay {toxinidir}/tests/ {posargs:}
-changedir = {toxworkdir}
+[pytest]
+testpaths = tests
+addopts = -ra -l
 
-[testenv:flake8]
-changedir = {toxinidir}
-deps =
-    flake8
-commands =
-    flake8 {toxworkdir} {posargs}
+[coverage:run]
+parallel = true
+branch = true
 
-[testenv:pylint]
-deps =
-    pylint
-    pytest
-changedir = {toxinidir}
-commands =
-    python -m pylint --rcfile=pylintrc --output-format=parseable corelay tests
+[coverage:report]
+skip_covered = true
+show_missing = true
+
+[coverage:paths]
+source = corelay
+    */.tox/*/lib/python*/site-packages/corelay
+    */corelay


### PR DESCRIPTION
## Tox: More python versions and building docs

- support python 3.7 - 3.9
- move flake8 to bottom, and execute only in py39
- reformat pytest command, add config for coverage
- add docs environment to build docs
- add coverage environment
- make pylint command locations more explicit, execute only in py39
- add pytest configuration
- add coverage configuration

## Docs: Added Sphinx Documentation

- add sphinx documentation
- add index, with a very brief explanation, install instructions,
  contents, and a reference to our paper
- add api reference with autosummary and autodoc
- add a getting started section, which briefly and practically
  demonstrates Params, Processors, Tasks and Pipelines
- add bibliography with reference to our paper
- add favicon.svg, which currently is an `s`, referring to the previous
  name of corelay
- autodoc: ignore properties to avoid doubling for now, since they are
  all documented as class attributes

## Docstring: Fix Docstring and NumpyDoc Issues

- remove trailing s after backticks
- add missing docstring headers
- use double backticks for inline-code
