### PR TITLE
Docs: Remove 'Sprincl' references

### DIFF
--- a/src/corelay/base.py
+++ b/src/corelay/base.py
@@ -1,4 +1,4 @@
-"""Module containing basic Sprincl classes, such as Param"""
+"""Module containing basic CoRelAy classes, such as Param"""
 from .plugboard import Slot
 
 

--- a/src/corelay/utils.py
+++ b/src/corelay/utils.py
@@ -1,4 +1,4 @@
-"""Sprincl utils contains conditional importing functionality.
+"""CoRelAy utils contains conditional importing functionality.
 
 """
 


### PR DESCRIPTION
- two files still referenced the project as 'Sprincl'
- changed the project name in those instances to 'CoRelAy'