### PR TITLE
Automated the Publishing of CoRelAy to PyPI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,60 @@
+
+# This workflow will build the CoRelAy project and publish the artifacts to PyPI when a GitHub release is created
+name: CoRelAy Continuous Deployment
+
+# This workflow will run when a new release is created on GitHub, the process works like this:
+#   1) For each milestone multiple issues are created
+#   2) For each issue a new branch is branched off from the develop branch (which itself is branched off from main)
+#   3) When the issue is resolved, a pull request is created to merge the issue branch into the develop branch
+#   4) Once all issues for a milestone are resolved, a pull request is created to merge the develop branch into the main branch
+#   5) When the pull request is merged, a new release is created
+#   6) This workflow will then be triggered and the CoRelAy project will be built and published to PyPI
+on:
+  release:
+    types:
+      - created
+
+# This workflow contains a single job for building and publishing the CoRelAy project
+jobs:
+
+  # Builds and publishes the CoRelAy project
+  build-and-publish:
+
+    # The job will run on the latest version of Ubuntu
+    name: Build and Publish the CoRelAy Project
+    runs-on: ubuntu-latest
+
+    # Gives the job permission to write the ID token, which is required for trusted publishing; trusted publishing is a way to publish packages to a
+    # package index (like PyPI) without needing to store credentials in the repository; trusted publishing is set up beforehand and during the
+    # publishing step and allows the job to automatically authenticate with the package index to retrieve a JWT token for publishing the package; the
+    # write permission is allows GitHub to generate an OIDC token, which is used to authenticate with the package index and retrieve the JWT token
+    permissions:
+      id-token: write
+
+    # Specifies that we want to deploy to PyPI
+    environment:
+      name: pypi
+      url: https://pypi.org/p/virelay
+
+    # The job contains several steps: 1) checking out the repository, 2) installing the Python project management tool uv, 3) installing Python, 4)
+    # installing the dependencies of CoRelAy, 5) building the CoRelAy project, and 6) publishing the CoRelAy project
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 0.6.13
+      - name: Install Python
+        run: uv python install 3.13.2
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+      - name: Install CoRelAy and its Dependencies
+        run: uv --directory source/backend sync --all-extras
+      - name: Build the CoRelAy Project
+        run: uv --directory source/backend build
+      - name: Publish the CoRelAy Project to PyPI
+        run: uv --directory source/backend publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Removed the GitHub Actions workflow matrix configurations for Python 3.7, as it is no longer supported by the project.
 - Added a job to the GitHub Actions workflow, which spell-checks the repository.
 - The GitHub Actions workflow now runs on pull requests and merges to the `main` and the `develop` branches. The workflow was previously only ran on pull requests and merges to the `main` branch. This was changed, because every feature branch that is to be merged into `develop` should be tested and linted before it is merged. Otherwise, build, test, and linting errors would only be detected just before the release of a new version, when the `develop` branch is merged into `main`.
+- Added a new GitHub Actions workflow, which builds the project and publishes it to PyPI. This workflow is triggered when GitHub release for a new version is created.
 - The configuration for the GitLab CI, which was stored in the `.gitlab-ci.yml` file, was removed. The project is no longer being hosted on GitLab, and the CI configuration is no longer needed.
 
 ### Documentation Updates in v0.3.0


### PR DESCRIPTION
Added a new GitHub Actions workflow, which builds the project and publishes it to PyPI. This workflow is triggered when GitHub release for a new version is created.

Closes issue #26.