### PR TITLE
Removed Node.js From the Deployment Workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,10 +48,6 @@ jobs:
           version: 0.6.13
       - name: Install Python
         run: uv python install 3.13.2
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.14.0'
       - name: Install CoRelAy and its Dependencies
         run: uv --directory source/backend sync
       - name: Build the CoRelAy Project


### PR DESCRIPTION
The GitHub Actions Workflow for the deployment of CoRelAy to PyPI was copied over from ViRelAy and still contained the installation of Node.js, which is needed in ViRelAy for the building of the frontend, but is not required for the building of CoRelAy. For this reason, the installation of Node.js was removed from the GitHub Actions Workflow for the deployment.

Closes issue #46.